### PR TITLE
Remove references to old AWS SDK

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -127,10 +127,6 @@ module Paperclip
           e.message << " (You may need to install the aws-sdk-s3 gem)"
           raise e
         end
-        if Gem::Version.new(Aws::VERSION) >= Gem::Version.new(2) &&
-           Gem::Version.new(Aws::VERSION) <= Gem::Version.new("2.0.33")
-          raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
-        end
 
         base.instance_eval do
           @s3_options     = @options[:s3_options]     || {}
@@ -157,11 +153,6 @@ module Paperclip
           @options[:url] = @options[:url].inspect if @options[:url].is_a?(Symbol)
 
           @http_proxy = @options[:http_proxy] || nil
-
-          if @options.has_key?(:use_accelerate_endpoint) &&
-              Gem::Version.new(Aws::VERSION) < Gem::Version.new("2.3.0")
-            raise LoadError, ":use_accelerate_endpoint is only available from aws-sdk version 2.3.0. Please upgrade aws-sdk to a newer version."
-          end
 
           @use_accelerate_endpoint = @options[:use_accelerate_endpoint]
         end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('appraisal')
   s.add_development_dependency('mocha')
-  s.add_development_dependency('aws-sdk', '>= 2.3.0', '< 3.0')
+  s.add_development_dependency('aws-sdk-s3')
   s.add_development_dependency('bourne')
   s.add_development_dependency('cucumber-rails')
   s.add_development_dependency('cucumber-expressions', '4.0.3') # TODO: investigate failures on 4.0.4

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 describe Paperclip::Storage::S3 do
   before do

--- a/spec/support/conditional_filter_helper.rb
+++ b/spec/support/conditional_filter_helper.rb
@@ -1,5 +1,5 @@
 module ConditionalFilterHelper
   def aws_accelerate_available?
-    (Gem::Version.new(Aws::VERSION) >= Gem::Version.new("2.3.0"))
+    true
   end
 end


### PR DESCRIPTION
This PR removes a few references to the old AWS SDK and adds `aws-sdk-s3` as a development dependency. This clears up almost all the spec failures on this repo.